### PR TITLE
Update Fabric support to Minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://fabricmc.net/develop/ for new versions
-    id 'fabric-loom' version '1.8-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.16-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.49-beta' apply false
 }

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -12,11 +12,6 @@ configurations {
 }
 
 dependencies {
-    compileOnly(project(':common')) {
-        capabilities {
-            requireCapability "$group:$mod_id"
-        }
-    }
     commonJava project(path: ':common', configuration: 'commonJava')
     commonResources project(path: ':common', configuration: 'commonResources')
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,19 +1,5 @@
 plugins {
     id 'multiloader-common'
-    id 'net.neoforged.moddev'
-}
-
-neoForge {
-    neoFormVersion = neo_form_version
-    // Automatically enable AccessTransformers if the file exists
-    def at = file('src/main/resources/META-INF/accesstransformer.cfg')
-    if (at.exists()) {
-        accessTransformers.from(at.absolutePath)
-    }
-    parchment {
-        minecraftVersion = parchment_minecraft
-        mappingsVersion = parchment_version
-    }
 }
 
 dependencies {

--- a/common/src/main/java/com/affehund/voidtotem/ModConstants.java
+++ b/common/src/main/java/com/affehund/voidtotem/ModConstants.java
@@ -1,6 +1,6 @@
 package com.affehund.voidtotem;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +20,7 @@ public class ModConstants {
     public static final String ADVANCEMENT_VOID_TOTEM_TITLE = "advancements." + MOD_ID + ".adventure." + ITEM_VOID_TOTEM + ".title";
     public static final String ADVANCEMENT_VOID_TOTEM_DESC = "advancements." + MOD_ID + ".adventure." + ITEM_VOID_TOTEM + ".description";
 
-    public static final ResourceLocation TOTEM_EFFECT_PACKET_LOCATION = ResourceLocation.fromNamespaceAndPath(MOD_ID, "totem_effect_packet");
+    public static final Identifier TOTEM_EFFECT_PACKET_LOCATION = Identifier.fromNamespaceAndPath(MOD_ID, "totem_effect_packet");
 
     public static final String CURIOS_MOD_ID = "curios";
     public static final String TRINKETS_MOD_ID = "trinkets";

--- a/common/src/main/java/com/affehund/voidtotem/client/VoidTotemParticle.java
+++ b/common/src/main/java/com/affehund/voidtotem/client/VoidTotemParticle.java
@@ -6,6 +6,7 @@ import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SimpleAnimatedParticle;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.NotNull;
 
 public class VoidTotemParticle extends SimpleAnimatedParticle {
@@ -36,7 +37,7 @@ public class VoidTotemParticle extends SimpleAnimatedParticle {
             this.sprites = sprites;
         }
 
-        public Particle createParticle(@NotNull SimpleParticleType type, @NotNull ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
+        public Particle createParticle(@NotNull SimpleParticleType type, @NotNull ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, @NotNull RandomSource randomSource) {
             return new VoidTotemParticle(level, x, y, z, xSpeed, ySpeed, zSpeed, this.sprites);
         }
     }

--- a/common/src/main/java/com/affehund/voidtotem/core/ModUtils.java
+++ b/common/src/main/java/com/affehund/voidtotem/core/ModUtils.java
@@ -34,9 +34,9 @@ public class ModUtils {
     }
 
     public static boolean canProtectFromVoid(LivingEntity entity, DamageSource source) {
-        String currentDim = entity.level().dimension().location().toString();
+        String currentDim = entity.level().dimension().identifier().toString();
         boolean isBlocklisted = Services.PLATFORM.isInvertedBlocklist() != Services.PLATFORM.getBlocklistedDimensions().contains(currentDim);
-        boolean isInVoid = source.is(DamageTypeTags.BYPASSES_INVULNERABILITY) && entity.getY() < entity.level().getMinBuildHeight();
+        boolean isInVoid = source.is(DamageTypeTags.BYPASSES_INVULNERABILITY) && entity.getY() < entity.level().getMinY();
         boolean isAwaitingPosition = entity instanceof ServerPlayer player && ((ServerGamePacketListenerImplAccessor) player.connection).getAwaitingPositionFromClient() != null;
 
         return !isBlocklisted && isInVoid && !isAwaitingPosition && hasVoidTotem(entity);
@@ -164,7 +164,7 @@ public class ModUtils {
 
     private static ItemStack getTotemFromInventory(LivingEntity entity) {
         if (Services.PLATFORM.useTotemFromInventory() && entity instanceof ServerPlayer player) {
-            return player.getInventory().items.stream()
+            return player.getInventory().getNonEquipmentItems().stream()
                     .filter(ModUtils::isVoidTotemItem)
                     .findFirst()
                     .orElse(null);
@@ -200,7 +200,7 @@ public class ModUtils {
             entity.teleportTo(lastPos.getX(), lastPos.getY(), lastPos.getZ());
         } else {
             BlockPos currentPos = entity.blockPosition();
-            entity.teleportTo(currentPos.getX(), entity.level().getMaxBuildHeight() + Services.PLATFORM.teleportHeightOffset(), currentPos.getZ());
+            entity.teleportTo(currentPos.getX(), entity.level().getMaxY() + Services.PLATFORM.teleportHeightOffset(), currentPos.getZ());
             if (entity instanceof ServerPlayer player) {
                 resetAboveGroundTickCount(player);
             }
@@ -215,7 +215,7 @@ public class ModUtils {
             return IntStream.range(0, 16)
                     .mapToObj(i -> {
                         double x = lastPos.getX() + (entity.getRandom().nextDouble() - 0.5) * 16.0;
-                        double y = Mth.clamp(lastPos.getY() + entity.getRandom().nextInt(16) - 8, level.getMinBuildHeight(), level.getMaxBuildHeight() - 1);
+                        double y = Mth.clamp(lastPos.getY() + entity.getRandom().nextInt(16) - 8, level.getMinY(), level.getMaxY() - 1);
                         double z = lastPos.getZ() + (entity.getRandom().nextDouble() - 0.5) * 16.0;
                         return new BlockPos((int) x, (int) y, (int) z);
                     })

--- a/common/src/main/java/com/affehund/voidtotem/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/com/affehund/voidtotem/mixin/LivingEntityMixin.java
@@ -62,8 +62,8 @@ public class LivingEntityMixin implements ILivingEntityMixin {
 
     @Inject(method = "readAdditionalSaveData", at = @At("TAIL"))
     public void readCustomDataFromNbt(@NotNull CompoundTag tag, CallbackInfo ci) {
-        this.voidtotem$isFallDamageImmune = tag.getBoolean(ModConstants.IS_FALL_DAMAGE_IMMUNE);
-        this.voidtotem$lastSaveBlockPos = tag.getLong(ModConstants.LAST_SAVE_BLOCK_POS);
+        this.voidtotem$isFallDamageImmune = tag.getBooleanOr(ModConstants.IS_FALL_DAMAGE_IMMUNE, false);
+        this.voidtotem$lastSaveBlockPos = tag.getLongOr(ModConstants.LAST_SAVE_BLOCK_POS, 0L);
     }
 
     @Inject(method = "addAdditionalSaveData", at = @At("TAIL"))

--- a/fabric/src/main/java/com/affehund/voidtotem/VoidTotemFabric.java
+++ b/fabric/src/main/java/com/affehund/voidtotem/VoidTotemFabric.java
@@ -12,7 +12,7 @@ import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
 import net.minecraft.core.Registry;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootPool;
@@ -30,8 +30,8 @@ public class VoidTotemFabric implements ModInitializer {
     public void onInitialize() {
         PayloadTypeRegistry.playS2C().register(TotemEffectPacket.TYPE, TotemEffectPacket.STREAM_CODEC);
 
-        Registry.register(BuiltInRegistries.ITEM, ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, ModConstants.ITEM_VOID_TOTEM), VOID_TOTEM_ITEM);
-        Registry.register(BuiltInRegistries.PARTICLE_TYPE, ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "void_totem"), VOID_TOTEM_PARTICLE);
+        Registry.register(BuiltInRegistries.ITEM, Identifier.fromNamespaceAndPath(ModConstants.MOD_ID, ModConstants.ITEM_VOID_TOTEM), VOID_TOTEM_ITEM);
+        Registry.register(BuiltInRegistries.PARTICLE_TYPE, Identifier.fromNamespaceAndPath(ModConstants.MOD_ID, "void_totem"), VOID_TOTEM_PARTICLE);
         ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.COMBAT).register(entries -> entries.addAfter(new ItemStack(Items.TOTEM_OF_UNDYING), VOID_TOTEM_ITEM));
 
         AutoConfig.register(VoidTotemAutoConfig.class, Toml4jConfigSerializer::new);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,34 +1,34 @@
 # Important Notes:
 # Every field you add must be added to buildSrc/src/main/groovy/multiloader-common.gradle expandProps map.
 # Project
-version=4.0.0
+version=4.0.1
 group=com.affehund.voidtotem
 java_version=21
 # Common
-minecraft_version=1.21.1
+minecraft_version=1.21.11
 mod_name=Void Totem
 mod_author=Affehund
 mod_id=voidtotem
 license=GPL-3.0
 credits=Thanks to all the translators, supporters, and helpers!
 description=A totem that prevents you from dying in the void.
-minecraft_version_range=[1.21.1]
+minecraft_version_range=[1.21.11]
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.1-20240808.144430
+neo_form_version=1.21.11-20251209.172050
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21
-parchment_version=2024.11.10
+parchment_minecraft=1.21.11
+parchment_version=2025.12.20
 # Fabric
-fabric_version=0.109.0+1.21.1
-fabric_loader_version=0.16.9
+fabric_version=0.141.3+1.21.11
+fabric_loader_version=0.18.5
 trinkets_version=3.10.0
-mod_menu_version=11.0.1
+mod_menu_version=17.0.0
 # NeoForge
 neoforge_version=21.1.127
 neoforge_loader_version_range=[4,)
 curios_version=9.2.2+1.21.1
-cloth_config_version=15.0.140
+cloth_config_version=21.11.153
 # Gradle
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ pluginManagement {
             filter {
                 includeGroup('net.fabricmc')
                 includeGroup('fabric-loom')
+                includeGroup('net.fabricmc.unpick')
             }
         }
         exclusiveContent {
@@ -44,7 +45,6 @@ plugins {
 }
 
 // This should match the folder name of the project, or else IDEA may complain (see https://youtrack.jetbrains.com/issue/IDEA-317606)
-rootProject.name = 'VoidTotem-Shared-1.21.1'
+rootProject.name = 'VoidTotem-Fabric-1.21.11'
 include('common')
 include('fabric')
-include('neoforge')


### PR DESCRIPTION
## Summary

- update the Fabric build to Minecraft 1.21.11
- remove the NeoForge module from the active build
- update Fabric API, Loader, Mod Menu, Cloth Config, Loom, and Gradle metadata
- apply the 1.21.11 API changes needed for the Fabric jar to compile
